### PR TITLE
ondisk: Add specific token accessors for compatibility.

### DIFF
--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -6543,6 +6543,141 @@ make_token_accessors! {
     }
 }
 
+// Compatibility shim for old token accessors (which we have a lot of
+// configurations with)
+impl<'a, 'b> Tokens<'a, 'b> {
+    #[allow(non_snake_case)]
+    pub fn mem_limit_memory_to_below_1_TiB(&self) -> Result<bool> {
+        bool::from_u32(self.get(TokenEntryId::Bool, 0x5e71e6d8)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    #[allow(non_snake_case)]
+    pub fn mem_uma_above_4_GiB(&self) -> Result<bool> {
+        bool::from_u32(self.get(TokenEntryId::Bool, 0x77e41d2a)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn df_remap_at_1tib(&self) -> Result<DfRemapAt1TiB> {
+        DfRemapAt1TiB::from_u32(self.get(TokenEntryId::Byte, 0x35ee_96f3)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn df_4link_max_xgmi_speed(&self) -> Result<DfXgmi4LinkMaxSpeed> {
+        DfXgmi4LinkMaxSpeed::from_u32(self.get(TokenEntryId::Byte, 0x3f307cb3)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn df_3link_max_xgmi_speed(&self) -> Result<DfXgmi3LinkMaxSpeed> {
+        DfXgmi3LinkMaxSpeed::from_u32(self.get(TokenEntryId::Byte, 0x53ba449b)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn mem_rdimm_timing_rcd_f0rc0f_additional_latency(&self) -> Result<MemRdimmTimingCmdParLatency> {
+        MemRdimmTimingCmdParLatency::from_u32(self.get(TokenEntryId::Byte, 0xd155798a)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn dimm_3ds_sensor_critical(&self) -> Result<u16> {
+        u16::from_u32(self.get(TokenEntryId::Word, 0x16b77f73)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn dimm_3ds_sensor_upper(&self) -> Result<u16> {
+        u16::from_u32(self.get(TokenEntryId::Word, 0x2db877e4)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn mother_board_type_0(&self) -> Result<bool> {
+        bool::from_u32(self.get(TokenEntryId::Bool, 0x536464b)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+}
+
+// Compatibility shim for old token accessors (which we have a lot of
+// configurations with)
+impl<'a, 'b> TokensMut<'a, 'b> {
+    #[allow(non_snake_case)]
+    pub fn mem_limit_memory_to_below_1_TiB(&self) -> Result<bool> {
+        bool::from_u32(self.get(TokenEntryId::Bool, 0x5e71e6d8)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    #[allow(non_snake_case)]
+    pub fn mem_uma_above_4_GiB(&self) -> Result<bool> {
+        bool::from_u32(self.get(TokenEntryId::Bool, 0x77e41d2a)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn df_remap_at_1tib(&self) -> Result<DfRemapAt1TiB> {
+        DfRemapAt1TiB::from_u32(self.get(TokenEntryId::Byte, 0x35ee_96f3)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn df_4link_max_xgmi_speed(&self) -> Result<DfXgmi4LinkMaxSpeed> {
+        DfXgmi4LinkMaxSpeed::from_u32(self.get(TokenEntryId::Byte, 0x3f307cb3)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn df_3link_max_xgmi_speed(&self) -> Result<DfXgmi3LinkMaxSpeed> {
+        DfXgmi3LinkMaxSpeed::from_u32(self.get(TokenEntryId::Byte, 0x53ba449b)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn mem_rdimm_timing_rcd_f0rc0f_additional_latency(&self)
+        -> Result<MemRdimmTimingCmdParLatency> {
+        MemRdimmTimingCmdParLatency::from_u32(self.get(TokenEntryId::Byte, 0xd155798a)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn dimm_3ds_sensor_critical(&self) -> Result<u16> {
+        u16::from_u32(self.get(TokenEntryId::Word, 0x16b77f73)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn dimm_3ds_sensor_upper(&self) -> Result<u16> {
+        u16::from_u32(self.get(TokenEntryId::Word, 0x2db877e4)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+    pub fn mother_board_type_0(&self) -> Result<bool> {
+        bool::from_u32(self.get(TokenEntryId::Bool, 0x536464b)?)
+            .ok_or_else(|| Error::EntryTypeMismatch)
+    }
+
+    #[allow(non_snake_case)]
+    pub fn set_mem_limit_memory_to_below_1_TiB(self: &'_ mut Self,
+        value: bool) -> Result<()> {
+        let token_value = value.to_u32().unwrap();
+        self.set(TokenEntryId::Bool, 0x5e71e6d8, token_value)
+    }
+    #[allow(non_snake_case)]
+    pub fn set_mem_uma_above_4_GiB(self: &'_ mut Self,
+        value: bool) -> Result<()> {
+        let token_value = value.to_u32().unwrap();
+        self.set(TokenEntryId::Bool, 0x77e41d2a, token_value)
+    }
+    pub fn set_df_remap_at_1tib(self: &'_ mut Self,
+        value: DfRemapAt1TiB) -> Result<()> {
+        let token_value = value.to_u32().unwrap();
+        self.set(TokenEntryId::Byte, 0x35ee_96f3, token_value)
+    }
+    pub fn set_df_4link_max_xgmi_speed(self: &'_ mut Self,
+        value: DfXgmi4LinkMaxSpeed) -> Result<()> {
+        let token_value = value.to_u32().unwrap();
+        self.set(TokenEntryId::Bool, 0x3f307cb3, token_value)
+    }
+    pub fn set_df_3link_max_xgmi_speed(self: &'_ mut Self,
+        value: DfXgmi3LinkMaxSpeed) -> Result<()> {
+        let token_value = value.to_u32().unwrap();
+        self.set(TokenEntryId::Bool, 0x53ba449b, token_value)
+    }
+    pub fn set_mem_rdimm_timing_rcd_f0rc0f_additional_latency(self: &'_ mut Self,
+        value: MemRdimmTimingCmdParLatency) -> Result<()> {
+        let token_value = value.to_u32().unwrap();
+        self.set(TokenEntryId::Byte, 0xd155798a, token_value)
+    }
+    pub fn set_dimm_3ds_sensor_critical(self: &'_ mut Self,
+        value: u16) -> Result<()> {
+        let token_value = value.to_u32().unwrap();
+        self.set(TokenEntryId::Word, 0x16b77f73, token_value)
+    }
+    pub fn set_dimm_3ds_sensor_upper(self: &'_ mut Self,
+        value: u16) -> Result<()> {
+        let token_value = value.to_u32().unwrap();
+        self.set(TokenEntryId::Word, 0x2db877e4, token_value)
+    }
+    pub fn set_mother_board_type_0(self: &'_ mut Self,
+        value: bool) -> Result<()> {
+        let token_value = value.to_u32().unwrap();
+        self.set(TokenEntryId::Bool, 0x536464b, token_value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
The Token API (without JSON) changed in an incompatible way because of amd-apcb commit 74ee37ad34539a0b2646c3dd9cc644f34e3694fd (providing enum variants for tokens).

This fixes the function names again.

See issue #6