### PR TITLE
ondisk: Make the bitfield fields default to Default if not specified in…

### DIFF
--- a/src/naples.rs
+++ b/src/naples.rs
@@ -28,6 +28,12 @@ impl Setter<ParameterTimePoint> for ParameterTimePoint {
     }
 }
 
+impl Default for ParameterTimePoint {
+    fn default() -> Self {
+        Self::Any
+    }
+}
+
 #[derive(
     Debug, PartialEq, num_derive::FromPrimitive, Clone, Copy, BitfieldSpecifier,
 )]
@@ -402,6 +408,12 @@ pub enum ParameterTokenConfig {
     Fch1c07 = 0x1C07, // FIXME
 
     Limit = 0x1FFF,
+}
+
+impl Default for ParameterTokenConfig {
+    fn default() -> Self {
+        Self::Limit
+    }
 }
 
 impl Getter<Result<ParameterTokenConfig>> for ParameterTokenConfig {

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -1132,6 +1132,9 @@ impl Default for GROUP_HEADER {
     }
 }
 
+/// A variant of the make_accessors macro for modular_bitfields.
+/// Note: fields that serde Deserialization cannot find in the source file
+/// will be defaulted.
 macro_rules! make_bitfield_serde {(
         $(#[$struct_meta:meta])*
         $struct_vis:vis
@@ -1199,8 +1202,8 @@ macro_rules! make_bitfield_serde {(
         #[cfg_attr(feature = "serde", serde(rename = "" $StructName))]
         pub(crate) struct [<Serde $StructName>] {
             $(
-                $(pub $field_name : <$field_ty as Specifier>::InOut,)?
-                $(pub $field_name : $serde_ty,)?
+                $(#[serde(default)] pub $field_name : <$field_ty as Specifier>::InOut,)?
+                $(#[serde(default)] pub $field_name : $serde_ty,)?
             )*
         }
     }
@@ -2636,6 +2639,7 @@ pub mod memory {
     pub struct CustomSerdeRdimmDdr4Voltages {
         #[cfg_attr(feature = "serde", serde(rename = "1.2 V"))]
         pub _1_2V: bool,
+        #[serde(default)]
         pub _reserved_1: u32,
     }
     macro_rules! define_compat_bitfield_field {
@@ -2806,6 +2810,7 @@ pub mod memory {
         pub _1_35V: bool,
         #[cfg_attr(feature = "serde", serde(rename = "1.25 V"))]
         pub _1_25V: bool,
+        #[serde(default)]
         pub _reserved_1: u32,
     }
     impl UdimmDdr4Voltages {
@@ -2907,6 +2912,7 @@ pub mod memory {
     pub struct CustomSerdeLrdimmDdr4Voltages {
         #[cfg_attr(feature = "serde", serde(rename = "1.2 V"))]
         pub _1_2V: bool,
+        #[serde(default)]
         pub _reserved_1: u32,
     }
 


### PR DESCRIPTION
… serde.

Before this PR, all fields of a bitfield, including reserved fields, had to be specified.

I think since we put this into amd-host-image-builder, it's better for that to default bitfield fields that were not specified in the JSON to the Default of that type (usually `false`), in order to cut down on the noise in the configuration.

This allows us to cut down on the total number of lines in the JSON by about 16% without touching any non-reserved fields in the JSON, only by removing the `_reserved_` lines from the JSON for bitfields.

Ideally, we would allow this only for `_reserved_` fields. But this implementation does it for ALL bitfield fields (since it's not clear to me how to make serde allow leaving off json fields by field name pattern). That also allows people to leave off other fields. But looking through the config we have, it's more user-friendly and not that dangerous to allow it for all fields anyway. There's still the risk of a weird default--but it's low.

This does not affect structs that are not bitfields.