### PR TITLE
entry: Fix typo in schema ("tokens" vs "Tokens").

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -444,7 +444,7 @@ impl<'a> schemars::JsonSchema for EntryItem<'a> {
         obj.properties
             .insert("header".to_owned(), <ENTRY_HEADER>::json_schema(gen));
         obj.properties.insert(
-            "Tokens".to_owned(),
+            "tokens".to_owned(),
             <Vec<TokensEntryItem<'_>>>::json_schema(gen),
         );
         obj.properties.insert(


### PR DESCRIPTION
There was a typo in the schema name of `tokens` which caused the intellisense in the configuration to not work for `tokens`.

This fixes it.
