### PR TITLE
apcb: When deserializing Apcb, ignore user-specified apcb_size.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,4 @@ tests:
 	$(CARGO) build --features serde
 	$(CARGO) build --features schemars,serde,serde-hex
 	$(CARGO) build --features serde,schemars --example fromyaml
+	$(CARGO) test --test '*' --features serde,schemars # integration tests only

--- a/src/apcb.rs
+++ b/src/apcb.rs
@@ -66,7 +66,7 @@ pub struct Apcb<'a> {
 pub struct SerdeApcb {
     pub version: String,
     pub header: V2_HEADER,
-    pub v3_header: Option<V3_HEADER_EXT>,
+    pub v3_header_ext: Option<V3_HEADER_EXT>,
     pub groups: Vec<SerdeGroupItem>,
     //#[cfg_attr(feature = "serde", serde(borrow))]
     pub entries: Vec<SerdeEntryItem>,
@@ -98,7 +98,7 @@ impl<'a> TryFrom<SerdeApcb> for Apcb<'a> {
             Cow::from(vec![0xFFu8; Self::MAX_SIZE]);
         let mut apcb = Apcb::create(buf, 42, &ApcbIoOptions::default())?;
         *apcb.header_mut()? = serde_apcb.header;
-        match serde_apcb.v3_header {
+        match serde_apcb.v3_header_ext {
             Some(v3) => {
                 assert!(size_of::<V3_HEADER_EXT>() + size_of::<V2_HEADER>() == 128);
                 apcb.header_mut()?.header_size.set(128);
@@ -175,12 +175,12 @@ impl<'a> Serialize for Apcb<'a> {
                 .header()
                 .map_err(|_| serde::ser::Error::custom("invalid V2_HEADER"))?,
         )?;
-        let v3_header: Option<V3_HEADER_EXT> = self
+        let v3_header_ext: Option<V3_HEADER_EXT> = self
             .v3_header_ext()
             .map_err(|e| serde::ser::Error::custom(format!("{:?}", e)))?
             .as_ref()
             .map(|h| **h);
-        state.serialize_field("v3_header_ext", &v3_header)?;
+        state.serialize_field("v3_header_ext", &v3_header_ext)?;
         state.serialize_field("groups", &groups)?;
         state.serialize_field("entries", &entries)?;
         state.end()

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,0 +1,145 @@
+
+const V3_CONFIG_STR: &str = r#"
+{
+        version: "0.1.0",
+        header: {
+                signature: "APCB",
+                header_size: 0x0000,
+                version: 48,
+                apcb_size: 0x00001274,
+                unique_apcb_instance: 0x00000002,
+                checksum_byte: 0x79,
+                _reserved_1: [
+                        0x00,
+                        0x00,
+                        0x00
+                ],
+                _reserved_2: [
+                        0x00000000,
+                        0x00000000,
+                        0x00000000
+                ]
+        },
+        v3_header_ext: {
+                signature: "ECB2",
+                _reserved_1: 0x0000,
+                _reserved_2: 0x0010,
+                struct_version: 18,
+                data_version: 256,
+                ext_header_size: 0x00000060,
+                _reserved_3: 0x0000,
+                _reserved_4: 0xffff,
+                _reserved_5: 0x0040,
+                _reserved_6: 0x0000,
+                _reserved_7: [
+                        0x00000000,
+                        0x00000000
+                ],
+                data_offset: 0x0058,
+                header_checksum: 0x00,
+                _reserved_8: 0x00,
+                _reserved_9: [
+                        0x00000000,
+                        0x00000000,
+                        0x00000000
+                ],
+                integrity_sign: [
+                        0x00,
+                        0x42,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00,
+                        0x00
+                ],
+                _reserved_10: [
+                        0x00000000,
+                        0x00000000,
+                        0x00000000
+                ],
+                signature_ending: "BCBA"
+        },
+        groups: [
+        ],
+        entries: [
+        ]
+}
+"#;
+
+const V2_CONFIG_STR: &str = r#"
+{
+        version: "0.1.0",
+        header: {
+                signature: "APCB",
+                header_size: 0x0000,
+                version: 48,
+                apcb_size: 0x00001274,
+                unique_apcb_instance: 0x00000002,
+                checksum_byte: 0x79,
+                _reserved_1: [
+                        0x00,
+                        0x00,
+                        0x00
+                ],
+                _reserved_2: [
+                        0x00000000,
+                        0x00000000,
+                        0x00000000
+                ]
+        },
+        groups: [
+        ],
+        entries: [
+        ]
+}
+"#;
+
+#[cfg(features = "serde")]
+#[test]
+fn test_v3_header() {
+    let configuration: amd_apcb::Apcb =
+        serde_yaml::from_str(&V3_CONFIG_STR)
+            .expect("configuration be valid JSON");
+    let header = configuration.header().unwrap();
+    assert_eq!(header.unique_apcb_instance().unwrap(), 2);
+    assert_eq!(header.header_size.get(), 128);
+    let v3_header_ext = configuration.v3_header_ext().unwrap().unwrap();
+    assert_eq!(v3_header_ext.integrity_sign[1], 0x42);
+}
+
+#[cfg(features = "serde")]
+#[test]
+fn test_v2_header() {
+    let configuration: amd_apcb::Apcb =
+        serde_yaml::from_str(&V2_CONFIG_STR)
+            .expect("configuration be valid JSON");
+    let header = configuration.header().unwrap();
+    assert_eq!(header.header_size.get(), 32);
+    assert_eq!(header.unique_apcb_instance().unwrap(), 2);
+    assert!(configuration.v3_header_ext().unwrap().is_none());
+}


### PR DESCRIPTION
Previously, the buffer into which the Apcb was deserialized was fixed size and was sized using `apcb_size` that the user specified (`apcb_size` is supposed to actual *used* size of the apcb, think `size` as opposed to `capacity`).
This was not the intention and is user-unfriendly.

Therefore, this changes it such that the buffer into which the Apcb is deserialized has maximal size. The user-specified `apcb_size` is ignored, and instead the value of `apcb_size` to go into the Apcb header is calculated by the size of the things that go into the body.

This fixes [amd-host-image-builder issue #55](https://github.com/oxidecomputer/amd-host-image-builder/issues/55).