### PR TITLE
entry: Sort tokens by key; also validate that they are sorted by key.

### DIFF
--- a/src/apcb.rs
+++ b/src/apcb.rs
@@ -144,6 +144,11 @@ impl<'a> TryFrom<SerdeApcb> for Apcb<'a> {
             };
         }
         apcb.update_checksum()?;
+        // That may seem overly paranoid--but the serde deserializers
+        // usually don't have a whole-world view (they only see their
+        // input subtree) and thus they sometimes can't validate
+        // everything on-the-fly.
+        apcb.validate()?;
         Ok(apcb)
     }
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -97,18 +97,6 @@ impl<'a> GroupIter<'a> {
             FileSystemError::InconsistentHeader,
             "ENTRY_HEADER::group_id",
         ))?;
-        ContextFormat::from_u8(header.context_format).ok_or(
-            Error::FileSystem(
-                FileSystemError::InconsistentHeader,
-                "ENTRY_HEADER::context_format",
-            ),
-        )?;
-        let context_type = ContextType::from_u8(header.context_type).ok_or(
-            Error::FileSystem(
-                FileSystemError::InconsistentHeader,
-                "ENTRY_HEADER::context_type",
-            ),
-        )?;
         let entry_size = header.entry_size.get() as usize;
 
         let payload_size = entry_size
@@ -131,17 +119,11 @@ impl<'a> GroupIter<'a> {
             }
         };
 
-        let unit_size = header.unit_size;
-        let entry_id = header.entry_id.get();
+        let body = EntryItemBody::<&[u8]>::from_slice(header, body)?;
 
         Ok(EntryItem {
             header,
-            body: EntryItemBody::<&'_ [u8]>::from_slice(
-                unit_size,
-                entry_id,
-                context_type,
-                body,
-            )?,
+            body,
         })
     }
 
@@ -290,12 +272,6 @@ impl<'a> GroupMutIter<'a> {
                     ));
                 }
             };
-        let context_type = ContextType::from_u8(header.context_type).ok_or(
-            Error::FileSystem(
-                FileSystemError::InconsistentHeader,
-                "ENTRY_HEADER::context_type",
-            ),
-        )?;
         let entry_size = header.entry_size.get() as usize;
 
         let payload_size = entry_size
@@ -318,16 +294,10 @@ impl<'a> GroupMutIter<'a> {
             }
         };
 
-        let unit_size = header.unit_size;
-        let entry_id = header.entry_id.get();
+        let body = EntryItemBody::<&mut [u8]>::from_slice(header, body)?;
         Ok(EntryMutItem {
             header,
-            body: EntryItemBody::<&'_ mut [u8]>::from_slice(
-                unit_size,
-                entry_id,
-                context_type,
-                body,
-            )?,
+            body,
         })
     }
 

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -1134,8 +1134,7 @@ make_accessors! {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ContextFormat {
     Raw = 0,
-    SortAscending = 1,  // (sort by unit size)
-    SortDescending = 2, // don't use
+    SortAscending = 1,  // (sort by key)
 }
 
 #[derive(FromPrimitive, ToPrimitive, Debug, PartialEq, Copy, Clone)]
@@ -1447,7 +1446,7 @@ impl Default for ENTRY_HEADER {
 
 pub const ENTRY_ALIGNMENT: usize = 4;
 
-#[derive(FromBytes, AsBytes, Clone)]
+#[derive(FromBytes, AsBytes, Clone, Unaligned)]
 #[repr(C, packed)]
 pub struct TOKEN_ENTRY {
     pub key: LU32,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -752,7 +752,7 @@ mod tests {
 
         match entry.body {
             EntryItemBody::Tokens(ref tokens) => {
-                let mut tokens = tokens.iter();
+                let mut tokens = tokens.iter().unwrap();
 
                 let token = tokens.next().ok_or(Error::TokenNotFound)?;
                 assert!(token.id() == 0xae46_cea4);
@@ -944,7 +944,7 @@ mod tests {
         let entry = entries.next().ok_or(Error::EntryNotFound)?;
         match entry.body {
             EntryItemBody::<_>::Tokens(tokens) => {
-                let mut tokens = tokens.iter();
+                let mut tokens = tokens.iter().unwrap();
                 let token = tokens.next().ok_or(Error::TokenNotFound)?;
                 assert!(token.id() == 0x014FBF20);
                 assert!(token.value() == 1);
@@ -1094,7 +1094,7 @@ mod tests {
         let entry = entries.next().ok_or(Error::EntryNotFound)?;
         match entry.body {
             EntryItemBody::<_>::Tokens(tokens) => {
-                let mut tokens = tokens.iter();
+                let mut tokens = tokens.iter().unwrap();
 
                 let token = tokens.next().ok_or(Error::TokenNotFound)?;
                 assert!(token.id() == 0x42);
@@ -1230,7 +1230,7 @@ mod tests {
         let entry = entries.next().ok_or(Error::EntryNotFound)?;
         match entry.body {
             EntryItemBody::<_>::Tokens(tokens) => {
-                let mut tokens = tokens.iter();
+                let mut tokens = tokens.iter().unwrap();
 
                 let token = tokens.next().ok_or(Error::TokenNotFound)?;
                 assert!(token.id() == 0x014FBF20);

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,6 +18,7 @@ pub enum Error {
     EntryUniqueKeyViolation,
     EntryTypeMismatch,
     TokenNotFound,
+    TokenOrderingViolation,
     TokenUniqueKeyViolation,
     TokenRange,
     ParameterNotFound,


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-apcb/issues/51>.