### PR TITLE
Adopt a consistent rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,0 @@
-max_width = 80
-wrap_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2021"
+max_width = 80
+use_small_heuristics = "Max"
+newline_style = "Unix"

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -4,8 +4,7 @@ use crate::ondisk::{
     take_header_from_collection, take_header_from_collection_mut,
     BoardInstances, ContextFormat, ContextType, EntryCompatible, EntryId,
     HeaderWithTail, MutSequenceElementFromBytes, PriorityLevels,
-    SequenceElementFromBytes,
-    TOKEN_ENTRY,
+    SequenceElementFromBytes, TOKEN_ENTRY,
 };
 use crate::ondisk::{Parameters, ParametersIter};
 use crate::tokens_entry::TokensEntryBodyItem;
@@ -40,7 +39,9 @@ pub enum EntryItemBody<BufferType> {
 }
 
 impl<'a> EntryItemBody<&'a mut [u8]> {
-    pub(crate) fn from_slice(header: &ENTRY_HEADER, b: &'a mut [u8],
+    pub(crate) fn from_slice(
+        header: &ENTRY_HEADER,
+        b: &'a mut [u8],
     ) -> Result<EntryItemBody<&'a mut [u8]>> {
         let context_type = ContextType::from_u8(header.context_type).ok_or(
             Error::FileSystem(
@@ -203,10 +204,7 @@ pub struct StructArrayEntryMutItem<'a, T: Sized + FromBytes + AsBytes> {
 
 impl<'a, T: 'a + Sized + FromBytes + AsBytes> StructArrayEntryMutItem<'a, T> {
     pub fn iter_mut(&mut self) -> StructArrayEntryMutIter<'_, T> {
-        StructArrayEntryMutIter {
-            buf: self.buf,
-            _item: PhantomData,
-        }
+        StructArrayEntryMutIter { buf: self.buf, _item: PhantomData }
     }
 }
 
@@ -351,10 +349,7 @@ impl<'a> EntryMutItem<'a> {
                         take_header_from_collection_mut::<H>(&mut buf)?;
                     Some((
                         header,
-                        StructArrayEntryMutItem {
-                            buf,
-                            _item: PhantomData,
-                        },
+                        StructArrayEntryMutItem { buf, _item: PhantomData },
                     ))
                 } else {
                     None
@@ -594,7 +589,8 @@ impl<'a> Serialize for EntryItem<'a> {
         // manually.
         match &self.body {
             EntryItemBody::<_>::Tokens(tokens) => {
-                let v = tokens.iter()
+                let v = tokens
+                    .iter()
                     .map_err(|e| serde::ser::Error::custom(format!("{:?}", e)))?
                     .collect::<Vec<_>>();
                 state.serialize_field("tokens", &v)?;
@@ -1162,10 +1158,7 @@ impl<'de> Deserialize<'de> for SerdeEntryItem {
                     header.ok_or_else(|| de::Error::missing_field("header"))?;
                 let body =
                     body.ok_or_else(|| de::Error::missing_field("body"))?;
-                Ok(SerdeEntryItem {
-                    header: header,
-                    body: body,
-                })
+                Ok(SerdeEntryItem { header: header, body: body })
             }
         }
         let mut result = deserializer.deserialize_struct(
@@ -1175,10 +1168,14 @@ impl<'de> Deserialize<'de> for SerdeEntryItem {
         )?;
         let header = &result.header;
         if header.context_format == ContextFormat::SortAscending as u8
-        && header.context_type == (ContextType::Tokens as u8) {
+            && header.context_type == (ContextType::Tokens as u8)
+        {
             let body = result.body.as_mut_slice();
-            let mut tokens = zerocopy::LayoutVerified::<_, [crate::ondisk::TOKEN_ENTRY]>::new_slice_unaligned(body)
-                .ok_or(de::Error::custom("tokens could not be sorted"))?;
+            let mut tokens = zerocopy::LayoutVerified::<
+                _,
+                [crate::ondisk::TOKEN_ENTRY],
+            >::new_slice_unaligned(body)
+            .ok_or(de::Error::custom("tokens could not be sorted"))?;
             tokens.sort_by(|a, b| a.key.get().cmp(&b.key.get()));
         }
         Ok(result)
@@ -1261,10 +1258,7 @@ pub struct StructArrayEntryItem<'a, T: Sized + FromBytes> {
 
 impl<'a, T: 'a + Sized + FromBytes> StructArrayEntryItem<'a, T> {
     pub fn iter(&self) -> StructArrayEntryIter<'_, T> {
-        StructArrayEntryIter {
-            buf: self.buf,
-            _item: PhantomData,
-        }
+        StructArrayEntryIter { buf: self.buf, _item: PhantomData }
     }
 
     /// This is mostly useful for Naples Parameters.  They are modeled as a
@@ -1392,10 +1386,7 @@ impl<'a> EntryItem<'a> {
                     let header = take_header_from_collection::<H>(&mut buf)?;
                     Some((
                         header,
-                        StructArrayEntryItem {
-                            buf,
-                            _item: PhantomData,
-                        },
+                        StructArrayEntryItem { buf, _item: PhantomData },
                     ))
                 } else {
                     None
@@ -1413,10 +1404,7 @@ impl<'a> EntryItem<'a> {
                 if T::is_entry_compatible(self.id(), buf) {
                     let element_count: usize = buf.len() / size_of::<T>();
                     if buf.len() == element_count * size_of::<T>() {
-                        Some(StructArrayEntryItem {
-                            buf,
-                            _item: PhantomData,
-                        })
+                        Some(StructArrayEntryItem { buf, _item: PhantomData })
                     } else {
                         None
                     }

--- a/src/group.rs
+++ b/src/group.rs
@@ -121,10 +121,7 @@ impl<'a> GroupIter<'a> {
 
         let body = EntryItemBody::<&[u8]>::from_slice(header, body)?;
 
-        Ok(EntryItem {
-            header,
-            body,
-        })
+        Ok(EntryItem { header, body })
     }
 
     pub(crate) fn next1(&mut self) -> Result<EntryItem<'a>> {
@@ -295,10 +292,7 @@ impl<'a> GroupMutIter<'a> {
         };
 
         let body = EntryItemBody::<&mut [u8]>::from_slice(header, body)?;
-        Ok(EntryMutItem {
-            header,
-            body,
-        })
+        Ok(EntryMutItem { header, body })
     }
 
     /// Find the place BEFORE which the entry (GROUP_ID, ENTRY_ID, INSTANCE_ID,
@@ -413,12 +407,10 @@ impl<'a> GroupMutIter<'a> {
                 "ENTRY_HEADER:entry_size",
             ))?;
         let padding_size =
-            padding_size
-                .checked_sub(payload_size)
-                .ok_or(Error::FileSystem(
-                    FileSystemError::PayloadTooBig,
-                    "ENTRY_HEADER:entry_size",
-                ))?;
+            padding_size.checked_sub(payload_size).ok_or(Error::FileSystem(
+                FileSystemError::PayloadTooBig,
+                "ENTRY_HEADER:entry_size",
+            ))?;
 
         // Make sure that move_insertion_point_before does not notice the new
         // uninitialized entry
@@ -469,9 +461,7 @@ impl<'a> GroupMutIter<'a> {
         // Note: The following is settable by the user via EntryMutItem
         // set-accessors: context_type, context_format, unit_size,
         // priority_mask, key_size, key_pos
-        header
-            .board_instance_mask
-            .set(u16::from(board_instance_mask));
+        header.board_instance_mask.set(u16::from(board_instance_mask));
         let body = take_body_from_collection_mut(&mut buf, payload_size, 1)
             .ok_or(Error::FileSystem(
                 FileSystemError::InconsistentHeader,
@@ -590,15 +580,13 @@ impl<'a> GroupMutItem<'a> {
             board_instance_mask,
             size_diff,
         )?;
-        let entry_size: u16 = entry_size
-            .try_into()
-            .map_err(|_| Error::ArithmeticOverflow)?;
+        let entry_size: u16 =
+            entry_size.try_into().map_err(|_| Error::ArithmeticOverflow)?;
         let entry = entries.next().ok_or(Error::EntryNotFound)?;
 
         if size_diff > 0 {
-            let size_diff: usize = size_diff
-                .try_into()
-                .map_err(|_| Error::ArithmeticOverflow)?;
+            let size_diff: usize =
+                size_diff.try_into().map_err(|_| Error::ArithmeticOverflow)?;
             old_used_size = old_used_size
                 .checked_sub(size_diff)
                 .ok_or(Error::ArithmeticOverflow)?
@@ -694,9 +682,8 @@ impl<'a> GroupMutItem<'a> {
             .entry_exact_mut(entry_id, instance_id, board_instance_mask)
             .ok_or(Error::EntryNotFound)?;
         entry.delete_token(token_id)?;
-        let mut token_size_diff: i64 = token_size
-            .try_into()
-            .map_err(|_| Error::ArithmeticOverflow)?;
+        let mut token_size_diff: i64 =
+            token_size.try_into().map_err(|_| Error::ArithmeticOverflow)?;
         token_size_diff = -token_size_diff;
         #[assure("If `size_diff > 0`, caller needs to have expanded the group by `size_diff` already.  If `size_diff < 0`, caller needs to call `resize_entry_by` BEFORE resizing the group.", reason = "Our caller will do that, after calling us")]
         self.resize_entry_by(

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -13,8 +13,8 @@ use crate::types::Result;
 use byteorder::{LittleEndian, ReadBytesExt};
 use core::clone::Clone;
 use core::cmp::Ordering;
-use core::convert::TryInto;
 use core::convert::TryFrom;
+use core::convert::TryInto;
 use core::mem::{size_of, take};
 use core::num::NonZeroU8;
 use four_cc::FourCC;
@@ -262,7 +262,6 @@ type SerdeHex16 = u16;
 type SerdeHex32 = u32;
 #[cfg(not(feature = "serde-hex"))]
 type SerdeHex64 = u64;
-
 
 macro_rules! make_array_accessors {
     ($res_ty:ty, $array_ty:ty) => {
@@ -1135,7 +1134,7 @@ make_accessors! {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ContextFormat {
     Raw = 0,
-    SortAscending = 1,  // (sort by key)
+    SortAscending = 1, // (sort by key)
 }
 
 #[derive(FromPrimitive, ToPrimitive, Debug, PartialEq, Copy, Clone)]
@@ -1793,10 +1792,7 @@ pub mod df {
     impl SlinkRegion {
         // Not sure why AMD still uses those--but it does use them, so whatever.
         pub fn dummy(socket: u8) -> SlinkRegion {
-            SlinkRegion {
-                socket,
-                ..Self::default()
-            }
+            SlinkRegion { socket, ..Self::default() }
         }
     }
 
@@ -2085,10 +2081,7 @@ pub mod memory {
     }
     impl Default for AblBreakpointControl {
         fn default() -> Self {
-            Self {
-                enable_breakpoint: BU8(1),
-                break_on_all_dies: BU8(1),
-            }
+            Self { enable_breakpoint: BU8(1), break_on_all_dies: BU8(1) }
         }
     }
 
@@ -3762,18 +3755,10 @@ pub mod memory {
 
     impl Gpio {
         pub fn new(pin: u8, iomux_control: u8, bank_control: u8) -> Self {
-            Self {
-                pin,
-                iomux_control,
-                bank_control,
-            }
+            Self { pin, iomux_control, bank_control }
         }
         pub fn default() -> Self {
-            Self {
-                pin: 0,
-                iomux_control: 0,
-                bank_control: 0,
-            }
+            Self { pin: 0, iomux_control: 0, bank_control: 0 }
         }
     }
 
@@ -4344,9 +4329,7 @@ Clone)]
         }
         #[inline]
         pub fn invalid() -> DdrPostPackageRepairElement {
-            Self {
-                body: [0, 0, 0, 0, 0, 0, 0, 0xff],
-            }
+            Self { body: [0, 0, 0, 0, 0, 0, 0, 0xff] }
         }
         #[inline]
         pub fn set_body(&mut self, value: Option<DdrPostPackageRepairBody>) {
@@ -5959,10 +5942,7 @@ pub mod psp {
 
     impl Default for BoardIdGettingMethodCustom {
         fn default() -> Self {
-            Self {
-                access_method: 0xF.into(),
-                feature_mask: 0.into(),
-            }
+            Self { access_method: 0xF.into(), feature_mask: 0.into() }
         }
     }
 
@@ -6017,10 +5997,7 @@ pub mod psp {
 
     impl BoardIdGettingMethodGpio {
         pub fn new(bit_locations: [Gpio; 4]) -> Self {
-            Self {
-                access_method: 3.into(),
-                bit_locations,
-            }
+            Self { access_method: 3.into(), bit_locations }
         }
     }
 
@@ -7304,7 +7281,7 @@ pub enum CbsMemSpeedDdr4 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum FchSmbusSpeed {
     Value(u8), /* x in 66 MHz / (4 x) */
-    // FIXME: Auto ?
+               // FIXME: Auto ?
 }
 impl FromPrimitive for FchSmbusSpeed {
     fn from_u64(value: u64) -> Option<Self> {

--- a/src/serializers.rs
+++ b/src/serializers.rs
@@ -75,15 +75,7 @@ impl_struct_serde_conversion!(
 impl_struct_serde_conversion!(
     PriorityLevels,
     SerdePriorityLevels,
-    [
-        hard_force,
-        high,
-        medium,
-        event_logging,
-        low,
-        normal,
-        _reserved_1,
-    ]
+    [hard_force, high, medium, event_logging, low, normal, _reserved_1,]
 );
 
 impl_struct_serde_conversion!(
@@ -270,14 +262,7 @@ impl_struct_serde_conversion!(
 impl_struct_serde_conversion!(
     GROUP_HEADER,
     SerdeGROUP_HEADER,
-    [
-        signature,
-        group_id,
-        header_size,
-        version,
-        _reserved_,
-        group_size,
-    ]
+    [signature, group_id, header_size, version, _reserved_, group_size,]
 );
 impl_struct_serde_conversion!(
     BoardIdGettingMethodEeprom,
@@ -303,14 +288,7 @@ impl_struct_serde_conversion!(
 impl_struct_serde_conversion!(
     SlinkRegion,
     SerdeSlinkRegion,
-    [
-        size,
-        alignment,
-        socket,
-        phys_nbio_map,
-        interleaving,
-        _reserved_,
-    ]
+    [size, alignment, socket, phys_nbio_map, interleaving, _reserved_,]
 );
 impl_struct_serde_conversion!(
     AblConsoleOutControl,
@@ -397,7 +375,11 @@ impl_struct_serde_conversion!(
     SerdeLrMaxFreqElement,
     [dimm_slots_per_channel, _reserved_, conditions, speeds,]
 );
-impl_struct_serde_conversion!(Gpio, SerdeGpio, [pin, iomux_control, bank_control,]);
+impl_struct_serde_conversion!(
+    Gpio,
+    SerdeGpio,
+    [pin, iomux_control, bank_control,]
+);
 impl_struct_serde_conversion!(
     ErrorOutControlBeepCode,
     CustomSerdeErrorOutControlBeepCode,
@@ -492,13 +474,7 @@ impl_struct_serde_conversion!(
 impl_struct_serde_conversion!(
     DimmSlotsSelection,
     SerdeDimmSlotsSelection,
-    [
-        dimm_slot_0,
-        dimm_slot_1,
-        dimm_slot_2,
-        dimm_slot_3,
-        _reserved_1,
-    ]
+    [dimm_slot_0, dimm_slot_1, dimm_slot_2, dimm_slot_3, _reserved_1,]
 );
 impl_struct_serde_conversion!(
     ChannelIdsSelection,
@@ -570,15 +546,7 @@ impl_struct_serde_conversion!(
 impl_struct_serde_conversion!(
     MemBusSpeed,
     SerdeMemBusSpeed,
-    [
-        type_,
-        payload_size,
-        sockets,
-        channels,
-        dimms,
-        timing_mode,
-        bus_speed,
-    ]
+    [type_, payload_size, sockets, channels, dimms, timing_mode, bus_speed,]
 );
 impl_struct_serde_conversion!(
     MaxCsPerChannel,
@@ -588,40 +556,17 @@ impl_struct_serde_conversion!(
 impl_struct_serde_conversion!(
     MemTechnology,
     SerdeMemTechnology,
-    [
-        type_,
-        payload_size,
-        sockets,
-        channels,
-        dimms,
-        technology_type,
-    ]
+    [type_, payload_size, sockets, channels, dimms, technology_type,]
 );
 impl_struct_serde_conversion!(
     WriteLevellingSeedDelay,
     SerdeWriteLevellingSeedDelay,
-    [
-        type_,
-        payload_size,
-        sockets,
-        channels,
-        dimms,
-        seed,
-        ecc_seed,
-    ]
+    [type_, payload_size, sockets, channels, dimms, seed, ecc_seed,]
 );
 impl_struct_serde_conversion!(
     RxEnSeed,
     SerdeRxEnSeed,
-    [
-        type_,
-        payload_size,
-        sockets,
-        channels,
-        dimms,
-        seed,
-        ecc_seed,
-    ]
+    [type_, payload_size, sockets, channels, dimms, seed, ecc_seed,]
 );
 impl_struct_serde_conversion!(
     LrDimmNoCs6Cs7Routing,
@@ -674,11 +619,7 @@ impl_struct_serde_conversion!(
 impl_struct_serde_conversion!(
     IdApcbMapping,
     SerdeIdApcbMapping,
-    [
-        id_and_feature_mask,
-        id_and_feature_value,
-        board_instance_index,
-    ]
+    [id_and_feature_mask, id_and_feature_value, board_instance_index,]
 );
 impl_struct_serde_conversion!(
     BoardIdGettingMethodCustom,
@@ -804,5 +745,12 @@ impl_struct_serde_conversion!(
 impl_struct_serde_conversion!(
     MemPmuBistTestSelect,
     SerdeMemPmuBistTestSelect,
-    [algorithm_1, algorithm_2, algorithm_3, algorithm_4, algorithm_5, _reserved_0,]
+    [
+        algorithm_1,
+        algorithm_2,
+        algorithm_3,
+        algorithm_4,
+        algorithm_5,
+        _reserved_0,
+    ]
 );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -766,9 +766,8 @@ mod tests {
         assert!(matches!(entries.next(), None));
 
         assert!(matches!(groups.next(), None));
-        let tokens = apcb
-            .tokens(0, BoardInstances::from_instance(0).unwrap())
-            .unwrap();
+        let tokens =
+            apcb.tokens(0, BoardInstances::from_instance(0).unwrap()).unwrap();
         assert!(tokens.abl_serial_baud_rate().unwrap() == BaudRate::_4800Baud);
 
         let _tokens = apcb
@@ -788,9 +787,7 @@ mod tests {
             )
             .unwrap();
         assert!(tokens.abl_serial_baud_rate().unwrap() == BaudRate::_4800Baud);
-        tokens
-            .set_abl_serial_baud_rate(BaudRate::_9600Baud)
-            .unwrap();
+        tokens.set_abl_serial_baud_rate(BaudRate::_9600Baud).unwrap();
         assert!(tokens.abl_serial_baud_rate().unwrap() == BaudRate::_9600Baud);
         Ok(())
     }
@@ -1191,8 +1188,7 @@ mod tests {
             Ok(_) => {
                 panic!("Validation should have failed")
             }
-            _ => {
-            }
+            _ => {}
         }
         // Try what happens when ABL0 version is old enough
         apcb.validate(Some(0x42)).unwrap();
@@ -1269,16 +1265,14 @@ mod tests {
             Ok(_) => {
                 panic!("Validation should have failed")
             }
-            _ => {
-            }
+            _ => {}
         }
         // Try what happens when ABL0 version is old enough
         match apcb.validate(Some(0x42)) {
             Ok(_) => {
                 panic!("Validation should have failed")
             }
-            _ => {
-            }
+            _ => {}
         }
         Ok(())
     }
@@ -1488,9 +1482,8 @@ mod tests {
         assert!(entry.instance_id() == 0);
         assert!(entry.board_instance_mask() == BoardInstances::all());
 
-        let mut platform_specific_overrides = entry
-            .body_as_struct_sequence_mut::<MutElementRef<'_>>()
-            .unwrap();
+        let mut platform_specific_overrides =
+            entry.body_as_struct_sequence_mut::<MutElementRef<'_>>().unwrap();
         let platform_specific_overrides =
             platform_specific_overrides.iter_mut().unwrap();
         let mut lvdimm_count = 0;
@@ -1561,12 +1554,8 @@ mod tests {
         let element = RdimmDdr4CadBusElement::new(
             2,
             DdrRates::new().with_ddr3200(true),
-            Ddr4DimmRanks::new()
-                .with_single_rank(true)
-                .with_dual_rank(true),
-            Ddr4DimmRanks::new()
-                .with_single_rank(true)
-                .with_dual_rank(true),
+            Ddr4DimmRanks::new().with_single_rank(true).with_dual_rank(true),
+            Ddr4DimmRanks::new().with_single_rank(true).with_dual_rank(true),
             0x2a2d2d,
         )
         .unwrap();
@@ -1595,9 +1584,8 @@ mod tests {
         assert!(entry.instance_id() == 0);
         assert!(entry.board_instance_mask() == BoardInstances::all());
 
-        let mut items = entry
-            .body_as_struct_array_mut::<RdimmDdr4CadBusElement>()
-            .unwrap();
+        let mut items =
+            entry.body_as_struct_array_mut::<RdimmDdr4CadBusElement>().unwrap();
         let mut items = items.iter_mut();
         let item = items.next().ok_or(Error::EntryNotFound)?;
 
@@ -1642,12 +1630,8 @@ mod tests {
         let element = Ddr4DataBusElement::new(
             2,
             DdrRates::new().with_ddr3200(true),
-            Ddr4DimmRanks::new()
-                .with_single_rank(true)
-                .with_dual_rank(true),
-            Ddr4DimmRanks::new()
-                .with_single_rank(true)
-                .with_dual_rank(true),
+            Ddr4DimmRanks::new().with_single_rank(true).with_dual_rank(true),
+            Ddr4DimmRanks::new().with_single_rank(true).with_dual_rank(true),
             RttNom::Off,
             RttWr::Off,
             RttPark::_48Ohm,
@@ -1680,9 +1664,8 @@ mod tests {
         assert!(entry.instance_id() == 0);
         assert!(entry.board_instance_mask() == BoardInstances::all());
 
-        let mut items = entry
-            .body_as_struct_array_mut::<Ddr4DataBusElement>()
-            .unwrap();
+        let mut items =
+            entry.body_as_struct_array_mut::<Ddr4DataBusElement>().unwrap();
         let mut items = items.iter_mut();
         let item = items.next().ok_or(Error::EntryNotFound)?;
 

--- a/src/token_accessors.rs
+++ b/src/token_accessors.rs
@@ -5,7 +5,10 @@ use crate::entry::EntryItemBody;
 use crate::ondisk::BoardInstances;
 use crate::ondisk::GroupId;
 use crate::ondisk::PriorityLevels;
-use crate::ondisk::{ContextType, EntryId, TokenEntryId, WordToken, DwordToken, ByteToken, BoolToken};
+use crate::ondisk::{
+    BoolToken, ByteToken, ContextType, DwordToken, EntryId, TokenEntryId,
+    WordToken,
+};
 use crate::types::Error;
 use crate::types::Result;
 
@@ -52,10 +55,8 @@ impl<'a, 'b> TokensMut<'a, 'b> {
         token_entry_id: TokenEntryId,
         field_key: u32,
     ) -> Result<u32> {
-        let group = self
-            .apcb
-            .group(GroupId::Token)?
-            .ok_or(Error::GroupNotFound)?;
+        let group =
+            self.apcb.group(GroupId::Token)?.ok_or(Error::GroupNotFound)?;
         let entry = group
             .entry_exact(
                 EntryId::Token(token_entry_id),
@@ -108,18 +109,30 @@ impl<'a, 'b> TokensMut<'a, 'b> {
                 };
                 if let Some(abl0_version) = self.abl0_version {
                     let valid = match token_entry_id {
-                        TokenEntryId::Bool => BoolToken::valid_for_abl0_raw(abl0_version, token_id),
-                        TokenEntryId::Byte => ByteToken::valid_for_abl0_raw(abl0_version, token_id),
-                        TokenEntryId::Word => WordToken::valid_for_abl0_raw(abl0_version, token_id),
-                        TokenEntryId::Dword => DwordToken::valid_for_abl0_raw(abl0_version, token_id),
-                        TokenEntryId::Unknown(_) => false
+                        TokenEntryId::Bool => BoolToken::valid_for_abl0_raw(
+                            abl0_version,
+                            token_id,
+                        ),
+                        TokenEntryId::Byte => ByteToken::valid_for_abl0_raw(
+                            abl0_version,
+                            token_id,
+                        ),
+                        TokenEntryId::Word => WordToken::valid_for_abl0_raw(
+                            abl0_version,
+                            token_id,
+                        ),
+                        TokenEntryId::Dword => DwordToken::valid_for_abl0_raw(
+                            abl0_version,
+                            token_id,
+                        ),
+                        TokenEntryId::Unknown(_) => false,
                     };
                     if !valid {
                         return Err(Error::TokenVersionMismatch {
                             entry_id: token_entry_id,
                             token_id,
                             abl0_version,
-                        })
+                        });
                     }
                 }
                 self.apcb.insert_token(
@@ -165,11 +178,7 @@ impl<'a, 'b> Tokens<'a, 'b> {
         instance_id: u16,
         board_instance_mask: BoardInstances,
     ) -> Result<Self> {
-        Ok(Self {
-            apcb,
-            instance_id,
-            board_instance_mask,
-        })
+        Ok(Self { apcb, instance_id, board_instance_mask })
     }
 
     pub fn get(
@@ -177,10 +186,8 @@ impl<'a, 'b> Tokens<'a, 'b> {
         token_entry_id: TokenEntryId,
         field_key: u32,
     ) -> Result<u32> {
-        let group = self
-            .apcb
-            .group(GroupId::Token)?
-            .ok_or(Error::GroupNotFound)?;
+        let group =
+            self.apcb.group(GroupId::Token)?.ok_or(Error::GroupNotFound)?;
         let entry = group
             .entry_exact(
                 EntryId::Token(token_entry_id),

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,4 +1,3 @@
-
 const V3_CONFIG_STR: &str = r#"
 {
         version: "0.1.0",
@@ -214,9 +213,8 @@ const V2_CONFIG_STR: &str = r#"
 #[cfg(feature = "serde")]
 #[test]
 fn test_v3_header() {
-    let configuration: amd_apcb::Apcb =
-        serde_yaml::from_str(&V3_CONFIG_STR)
-            .expect("configuration be valid JSON");
+    let configuration: amd_apcb::Apcb = serde_yaml::from_str(&V3_CONFIG_STR)
+        .expect("configuration be valid JSON");
     let header = configuration.header().unwrap();
     assert_eq!(header.unique_apcb_instance().unwrap(), 2);
     assert_eq!(header.header_size.get(), 128);
@@ -227,9 +225,8 @@ fn test_v3_header() {
 #[cfg(feature = "serde")]
 #[test]
 fn test_v2_header() {
-    let configuration: amd_apcb::Apcb =
-        serde_yaml::from_str(&V2_CONFIG_STR)
-            .expect("configuration be valid JSON");
+    let configuration: amd_apcb::Apcb = serde_yaml::from_str(&V2_CONFIG_STR)
+        .expect("configuration be valid JSON");
     let header = configuration.header().unwrap();
     assert_eq!(header.header_size.get(), 32);
     assert_eq!(header.unique_apcb_instance().unwrap(), 2);


### PR DESCRIPTION
Use a more "standard" rustfmt configuration and
format.  This change is purely mechanical.