### PR TITLE
Rename "SerdeApcb" to "Apcb" in serde

### DIFF
--- a/src/apcb.rs
+++ b/src/apcb.rs
@@ -64,6 +64,7 @@ pub struct Apcb<'a> {
 
 #[cfg(feature = "serde")]
 #[cfg_attr(feature = "serde", derive(Default, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename = "Apcb"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SerdeApcb {


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-apcb/issues/104>.