### PR TITLE
ondisk: Default EspiInit's _dummy values and rename them to _reserved.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amd-apcb"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Oxide Computer"]
 edition = "2021"
 

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -6502,17 +6502,17 @@ pub mod fch {
             cputemp_rtctime_vw_enabled || bool : BU8 | pub get bool : pub set bool,
             cputemp_rtctime_vw_index_select || SerdeHex8 : u8 | pub get u8 : pub set u8, // FIXME what's that?
 
-            _dummy_1 : u8,
-            _dummy_2 : u8,
+            _reserved_1 || #[serde(default)] u8 : u8,
+            _reserved_2 || #[serde(default)] u8 : u8,
 
             cpu_temp_mmio_base || SerdeHex32 : LU32, // 0: none
             rtc_time_mmio_base || SerdeHex32 : LU32, // 0: none
 
             bus_master_enabled || bool : BU8 | pub get bool : pub set bool,
 
-            _dummy_3: u8,
-            _dummy_4: u8,
-            _dummy_5: u8,
+            _reserved_3 || #[serde(default)] u8 : u8,
+            _reserved_4 || #[serde(default)] u8 : u8,
+            _reserved_5 || #[serde(default)] u8 : u8,
         }
     }
 

--- a/src/serializers.rs
+++ b/src/serializers.rs
@@ -879,14 +879,14 @@ impl_struct_serde_conversion!(
         irq_polarity,
         cputemp_rtctime_vw_enabled,
         cputemp_rtctime_vw_index_select,
-        _dummy_1,
-        _dummy_2,
+        _reserved_1,
+        _reserved_2,
         cpu_temp_mmio_base,
         rtc_time_mmio_base,
         bus_master_enabled,
-        _dummy_3,
-        _dummy_4,
-        _dummy_5,
+        _reserved_3,
+        _reserved_4,
+        _reserved_5,
     ]
 );
 impl_struct_serde_conversion!(


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-apcb/issues/130>.