### PR TITLE
ondisk: Add compat deserializer for FchConsoleOutMode.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amd-apcb"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Oxide Computer"]
 edition = "2021"
 

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -7218,12 +7218,67 @@ pub enum CcxSmtControl {
 }
 
 #[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum FchConsoleOutMode {
     Disabled = 0,
     Enabled = 1,
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for FchConsoleOutMode {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        struct ModeVisitor;
+        impl<'de> serde::de::Visitor<'de> for ModeVisitor {
+            type Value = FchConsoleOutMode;
+            fn expecting(
+                &self,
+                formatter: &mut core::fmt::Formatter<'_>,
+            ) -> core::fmt::Result {
+                formatter.write_str("'Disabled', 'Enabled', 0 or 1")
+            }
+            fn visit_str<E: serde::de::Error>(
+                self,
+                v: &str,
+            ) -> core::result::Result<Self::Value, E> {
+                match v {
+                    "Disabled" => Ok(FchConsoleOutMode::Disabled),
+                    "Enabled" => Ok(FchConsoleOutMode::Enabled),
+                    _ => Err(serde::de::Error::custom(
+                        "'Disabled', 'Enabled', 0 or 1 was expected",
+                    )),
+                }
+            }
+            fn visit_i64<E: serde::de::Error>(
+                self,
+                value: i64,
+            ) -> core::result::Result<Self::Value, E> {
+                match value {
+                    0 => Ok(FchConsoleOutMode::Disabled),
+                    1 => Ok(FchConsoleOutMode::Enabled),
+                    _ => Err(serde::de::Error::custom(
+                        "'Disabled', 'Enabled', 0 or 1 was expected",
+                    )),
+                }
+            }
+            fn visit_u64<E: serde::de::Error>(
+                self,
+                value: u64,
+            ) -> core::result::Result<Self::Value, E> {
+                match value {
+                    0 => Ok(FchConsoleOutMode::Disabled),
+                    1 => Ok(FchConsoleOutMode::Enabled),
+                    _ => Err(serde::de::Error::custom(
+                        "'Disabled', 'Enabled', 0 or 1 was expected",
+                    )),
+                }
+            }
+        }
+        deserializer.deserialize_any(ModeVisitor)
+    }
 }
 
 #[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Copy, Clone)]

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -1,0 +1,60 @@
+#[cfg(feature = "serde")]
+#[test]
+#[allow(non_snake_case)]
+fn test_current_FchConsoleOutMode_Disabled() {
+    let mode: amd_apcb::FchConsoleOutMode =
+        serde_yaml::from_str("\"Disabled\"")
+            .expect("configuration be valid JSON");
+    assert_eq!(mode, amd_apcb::FchConsoleOutMode::Disabled);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+#[allow(non_snake_case)]
+fn test_current_FchConsoleOutMode_Enabled() {
+    let mode: amd_apcb::FchConsoleOutMode = serde_yaml::from_str("\"Enabled\"")
+        .expect("configuration be valid JSON");
+    assert_eq!(mode, amd_apcb::FchConsoleOutMode::Enabled);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+#[allow(non_snake_case)]
+fn test_compat_FchConsoleOutMode_0() {
+    let mode: amd_apcb::FchConsoleOutMode =
+        serde_yaml::from_str("0").expect("configuration be valid JSON");
+    assert_eq!(mode, amd_apcb::FchConsoleOutMode::Disabled);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+#[allow(non_snake_case)]
+fn test_compat_FchConsoleOutMode_1() {
+    let mode: amd_apcb::FchConsoleOutMode =
+        serde_yaml::from_str("1").expect("configuration be valid JSON");
+    assert_eq!(mode, amd_apcb::FchConsoleOutMode::Enabled);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+#[allow(non_snake_case)]
+fn test_invalid_FchConsoleOutMode() {
+    match serde_yaml::from_str::<amd_apcb::FchConsoleOutMode>("\"Disabledx\"") {
+        Ok(_) => {
+            panic!("unexpected success");
+        }
+        Err(_) => {}
+    };
+}
+
+#[cfg(feature = "serde")]
+#[test]
+#[allow(non_snake_case)]
+fn test_invalid_FchConsoleOutMode_5() {
+    match serde_yaml::from_str::<amd_apcb::FchConsoleOutMode>("5") {
+        Ok(_) => {
+            panic!("unexpected success");
+        }
+        Err(_) => {}
+    };
+}


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-apcb/issues/132>.