### PR TITLE
apcb: ApcbIoOptions: Add check_signature_ending.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amd-apcb"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Oxide Computer"]
 edition = "2021"
 


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-apcb/issues/137>.