### PR TITLE
add alternative header ending signature

### DIFF
--- a/src/apcb.rs
+++ b/src/apcb.rs
@@ -1268,8 +1268,12 @@ impl<'a> Apcb<'a> {
                     "V3_HEADER_EXT::data_offset",
                 ));
             }
+            // NOTE: The AMD docs for Turin, Genoa, Milan and Rome say `BCPA`,
+            // i.e., `APCB` backwards. Some vendors are using `BCBA` instead,
+            // e.g., ASRock and coreboot (`3rdparty/blobs/mainboard/`).
             if !options.check_signature_ending
                 || value.signature_ending == *b"BCPA"
+                || value.signature_ending == *b"BCBA"
             {
             } else {
                 return Err(Error::FileSystem(


### PR DESCRIPTION
I don't know if this is a typo here in amd-apcb or both are possible.

I have seen "BCBA" in a firmware image from an ASRock A520M-HVS board, version A52MIX_2.73.
And it is also in Fiano (just in different notation):
https://github.com/linuxboot/fiano/blob/d844cd98141518f41b3e4012bcf419984074a2b4/pkg/amd/apcb/internal.go#L16