### PR TITLE
ondisk: add BDAT tokens

### DIFF
--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -10245,6 +10245,15 @@ pub enum MemMbistPerBitSlaveDieReportDdr {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum MemMbistDataEyeSilentExecutionDdr {
+    Disabled = 0,
+    Enabled = 1,
+}
+
+#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum MemSelfHealing {
     Disabled = 0,
     Pmu = 1,
@@ -10257,6 +10266,15 @@ pub enum MemSelfHealing {
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum BdatSupport {
+    Disabled = 0,
+    Enabled = 1,
+}
+
+#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum BdatPrintData {
     Disabled = 0,
     Enabled = 1,
 }
@@ -10611,11 +10629,14 @@ make_token_accessors! {
         #[cfg_attr(feature = "serde-hex", serde(serialize_with = "SerHex::<StrictPfx>::serialize", deserialize_with = "SerHex::<StrictPfx>::deserialize"))]
         MemMbistPatternLengthDdr(default 0, id 0x108b_b3e6) | pub get u8 : pub set u8,
         MemMbistPerBitSlaveDieReportDdr(default 0xff, id 0x3b78_2d55) | pub get MemMbistPerBitSlaveDieReportDdr : pub set MemMbistPerBitSlaveDieReportDdr,
-        MemMbistDataEyeSilentExecutionDdr(default 0, id 0x8ee6_e78f) | pub get MemMbistTest : pub set MemMbistTest,
+        /// Enables MBIST DDR margining data to be populated in the BDAT (Schema 8 Types 6 & 7).
+        MemMbistDataEyeSilentExecutionDdr(default 0, id 0x8ee6_e78f) | pub get MemMbistDataEyeSilentExecutionDdr : pub set MemMbistDataEyeSilentExecutionDdr,
 
         // BDAT for Genoa, Bergamo, Turin
+        /// Controls whether BDAT entries are populated and present in the system memory map.
         BdatSupport(default 0, id 0x2fad_02d2) | pub get BdatSupport : pub set BdatSupport,
-        BdatPrintData(default 0, id 0xd232_e51c) | pub get BdatSupport : pub set BdatSupport,
+        /// Enables dumping the BDAT entries to the serial console by the ABL during boot.
+        BdatPrintData(default 0, id 0xd232_e51c) | pub get BdatPrintData : pub set BdatPrintData,
 
         // Unsorted Milan; defaults wrong!
 

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -10256,6 +10256,15 @@ pub enum MemSelfHealing {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum BdatSupport {
+    Disabled = 0,
+    Enabled = 1,
+}
+
+#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum DfPdrTuningMode {
     MemorySensity = 0,
     CacheBound = 1,
@@ -10592,7 +10601,7 @@ make_token_accessors! {
         MemMbistPatternSelect(default 0, id 0xf527ebf8) | pub get MemMbistPatternSelect : pub set MemMbistPatternSelect, // Rome
         MemMbistAggressorOn(default 0, id 0x32361c4) | pub get bool : pub set bool, // Rome; obsolete
 
-        // MBIST for Genoa & Bergamo
+        // MBIST for Genoa, Bergamo, Turin
         MemMbistDdrMode(default 0, id 0x7dcb_2da5) | pub get MemMbistDdrMode: pub set MemMbistDdrMode,
         MemMbistAggressorsDdr(default 0, id 0xb46e_f9ab) | pub get MemMbistDdrMode : pub set MemMbistDdrMode,
         MemMbistAggressorsChannelDdrMode(default 0, id 0x2fc_8ca9) | pub get MemMbistAggressorsChannelDdrMode : pub set MemMbistAggressorsChannelDdrMode,
@@ -10602,6 +10611,10 @@ make_token_accessors! {
         #[cfg_attr(feature = "serde-hex", serde(serialize_with = "SerHex::<StrictPfx>::serialize", deserialize_with = "SerHex::<StrictPfx>::deserialize"))]
         MemMbistPatternLengthDdr(default 0, id 0x108b_b3e6) | pub get u8 : pub set u8,
         MemMbistPerBitSlaveDieReportDdr(default 0xff, id 0x3b78_2d55) | pub get MemMbistPerBitSlaveDieReportDdr : pub set MemMbistPerBitSlaveDieReportDdr,
+
+        // BDAT for Genoa, Bergamo, Turin
+        BdatSupport(default 0, id 0x2fad_02d2) | pub get BdatSupport : pub set BdatSupport,
+        BdatPrintData(default 0, id 0xd232_e51c) | pub get BdatSupport : pub set BdatSupport,
 
         // Unsorted Milan; defaults wrong!
 

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -10611,6 +10611,7 @@ make_token_accessors! {
         #[cfg_attr(feature = "serde-hex", serde(serialize_with = "SerHex::<StrictPfx>::serialize", deserialize_with = "SerHex::<StrictPfx>::deserialize"))]
         MemMbistPatternLengthDdr(default 0, id 0x108b_b3e6) | pub get u8 : pub set u8,
         MemMbistPerBitSlaveDieReportDdr(default 0xff, id 0x3b78_2d55) | pub get MemMbistPerBitSlaveDieReportDdr : pub set MemMbistPerBitSlaveDieReportDdr,
+        MemMbistDataEyeSilentExecutionDdr(default 0, id 0x8ee6_e78f) | pub get MemMbistTest : pub set MemMbistTest,
 
         // BDAT for Genoa, Bergamo, Turin
         BdatSupport(default 0, id 0x2fad_02d2) | pub get BdatSupport : pub set BdatSupport,


### PR DESCRIPTION
- `APCB_TOKEN_UID_BDAT_SUPPORT`
    Controls whether BDAT entries are populated at all and present in the system memory map.

- `APCB_TOKEN_UID_BDAT_PRINT_DATA`
    Enables dumping the contents of the various BDAT entries to the serial console by the ABL.

- `APCB_TOKEN_UID_MEM_MBIST_DATAEYE_SILENT_EXECUTION_DDR`
    Enables MBIST DDR margining data to be populated in the BDAT (Schema 8 Types 6 & 7).