### PR TITLE
Bump MAX_SIZE to support dumping Turin 1.0.0.4.

### DIFF
--- a/src/apcb.rs
+++ b/src/apcb.rs
@@ -442,7 +442,7 @@ impl<'a> Apcb<'a> {
     const ROME_VERSION: u16 = 0x30;
     const V3_HEADER_EXT_SIZE: usize =
         size_of::<V2_HEADER>() + size_of::<V3_HEADER_EXT>();
-    pub const MAX_SIZE: usize = 0x8000;
+    pub const MAX_SIZE: usize = 0x10000;
 
     pub fn header(&self) -> Result<LayoutVerified<&[u8], V2_HEADER>> {
         LayoutVerified::<&[u8], V2_HEADER>::new_unaligned_from_prefix(


### PR DESCRIPTION
Tried dumping Turin 1.0.0.4 but ran into a panic:

```
$ target/debug/amd-host-image-builder dump -i RRRT1004E.FD -b dump
thread 'main' panicked at src/main.rs:804:53:
range end index 49152 out of range for slice of length 32768
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Looks like it's increased to `49152 (0xC000)` but I just went ahead and doubled `MAX_SIZE` for when they inevitably increase it once again.