### PR TITLE
cleanup: clippy clean

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 byteorder = { version = "1.4", default-features = false }
 four-cc = { version =  "0.4", default-features = false }
 memoffset = "0.9"
-modular-bitfield = { version = "0.11", default-features = false }
+modular-bitfield = { version = "0.13", default-features = false }
 num-derive = { version = "0.4", features = [ ] }
 num-traits = { version = "0.2", default-features = false }
 paste = "1.0"

--- a/src/apcb.rs
+++ b/src/apcb.rs
@@ -740,7 +740,7 @@ impl<'a> Apcb<'a> {
                     .map_err(|_| Error::ArithmeticOverflow)?,
             )
             .ok_or(Error::OutOfSpace)?;
-        while entry_allocation % (ENTRY_ALIGNMENT as u16) != 0 {
+        while !entry_allocation.is_multiple_of(ENTRY_ALIGNMENT as u16) {
             entry_allocation += 1;
         }
         let mut group =
@@ -1008,7 +1008,7 @@ impl<'a> Apcb<'a> {
         // tested, are impossible right now anyway and have never been seen.  So
         // disallow those.
         const TOKEN_SIZE: u16 = size_of::<TOKEN_ENTRY>() as u16;
-        const_assert!(TOKEN_SIZE % (ENTRY_ALIGNMENT as u16) == 0);
+        const_assert!(TOKEN_SIZE.is_multiple_of(ENTRY_ALIGNMENT as u16));
         let mut group = self.resize_group_by(group_id, TOKEN_SIZE.into())?;
         // Now, GroupMutItem.buf includes space for the token, claimed by no
         // entry so far.  group.insert_token has special logic in order to

--- a/src/group.rs
+++ b/src/group.rs
@@ -376,7 +376,7 @@ impl GroupMutIter<'_> {
                         offset = offset
                             .checked_add(entry_size.into())
                             .ok_or(Error::ArithmeticOverflow)?;
-                        while offset % ENTRY_ALIGNMENT != 0 {
+                        while !offset.is_multiple_of(ENTRY_ALIGNMENT) {
                             offset = offset
                                 .checked_add(1)
                                 .ok_or(Error::ArithmeticOverflow)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ struct SerdeFoo {
     // and stored without warning (which is what a lot of Rust crates
     // culturally do--see for example register crates, hal crates etc).
     // To prevent truncation is why, whenever possible, we use an
-    // enum that derives BitfieldSpecifier instead of things like B3.
+    // enum that derives Specifier instead of things like B3.
     // That way, out of bounds values cannot happen.
     // These enums can be used as `TYPE` directly in `#[bitfield]` fields.
     pub a: Quux

--- a/src/naples.rs
+++ b/src/naples.rs
@@ -9,7 +9,7 @@ use crate::types::Result;
 use modular_bitfield::prelude::*;
 
 #[derive(
-    Debug, PartialEq, num_derive::FromPrimitive, Clone, Copy, BitfieldSpecifier,
+    Debug, Default, PartialEq, num_derive::FromPrimitive, Clone, Copy, Specifier,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
@@ -18,6 +18,7 @@ use modular_bitfield::prelude::*;
 #[bits = 8]
 pub enum ParameterTimePoint {
     Never = 0,
+    #[default]
     Any = 1,
 }
 
@@ -33,14 +34,8 @@ impl Setter<ParameterTimePoint> for ParameterTimePoint {
     }
 }
 
-impl Default for ParameterTimePoint {
-    fn default() -> Self {
-        Self::Any
-    }
-}
-
 #[derive(
-    Debug, PartialEq, num_derive::FromPrimitive, Clone, Copy, BitfieldSpecifier,
+    Debug, Default, PartialEq, num_derive::FromPrimitive, Clone, Copy, Specifier,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
@@ -413,13 +408,8 @@ pub enum ParameterTokenConfig {
     Fch1c06 = 0x1C06, // FIXME
     Fch1c07 = 0x1C07, // FIXME
 
+    #[default]
     Limit = 0x1FFF,
-}
-
-impl Default for ParameterTokenConfig {
-    fn default() -> Self {
-        Self::Limit
-    }
 }
 
 impl Getter<Result<ParameterTokenConfig>> for ParameterTokenConfig {

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -1438,7 +1438,7 @@ pub mod gnb {
         Immutable, IntoBytes, KnownLayout, Result, Setter, Specifier,
         ToPrimitive, Unaligned, make_bitfield_serde, paste,
     };
-    use crate::struct_accessors::make_accessors;
+    use crate::struct_accessors::make_accessors_base;
     use modular_bitfield::prelude::*;
 
     #[derive(
@@ -1557,7 +1557,7 @@ pub mod gnb {
         u64
     );
 
-    make_accessors! {
+    make_accessors_base! {
         #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned, Debug, Copy, Clone)]
         #[repr(C, packed)]
         pub struct EarlyPcieConfigElement {
@@ -2084,6 +2084,7 @@ pub mod memory {
     use super::*;
     use crate::struct_accessors::{
         BLU16, BU8, DummyErrorChecks, Getter, Setter, make_accessors,
+        make_accessors_base, make_bitfield_serde_base,
     };
     use crate::types::Result;
 
@@ -2839,7 +2840,7 @@ pub mod memory {
         }
     }
 
-    make_bitfield_serde! {
+    make_bitfield_serde_base! {
         #[bitfield(bits = 32)]
         #[repr(u32)]
         #[derive(Clone, Copy)]
@@ -3002,7 +3003,7 @@ pub mod memory {
         }
     }
 
-    make_bitfield_serde! {
+    make_bitfield_serde_base! {
         #[bitfield(bits = 32)]
         #[repr(u32)]
         #[derive(Clone, Copy)]
@@ -3097,7 +3098,7 @@ pub mod memory {
         }
     }
 
-    make_bitfield_serde! {
+    make_bitfield_serde_base! {
         #[bitfield(bits = 32)]
         #[repr(u32)]
         #[derive(Clone, Copy)]
@@ -4445,7 +4446,7 @@ pub mod memory {
         Smu = 9,
         Unknown = 0xf, // that's specified as "Unknown".
     }
-    make_accessors! {
+    make_accessors_base! {
         #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned, PartialEq, Debug, Copy, Clone)]
         #[repr(C, packed)]
         pub struct ErrorOutControlBeepCode {
@@ -4933,7 +4934,7 @@ Clone)]
         u64
     );
 
-    make_accessors! {
+    make_accessors_base! {
         #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned, Debug, Copy, Clone)]
         #[repr(C, packed)]
         pub struct DdrPostPackageRepairElement {

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -125,7 +125,8 @@ pub(crate) fn take_body_from_collection_mut<'a>(
     let xbuf = take(&mut *buf);
     if xbuf.len() >= size {
         let (item, xbuf) = xbuf.split_at_mut(size);
-        if size % alignment != 0 && xbuf.len() >= alignment - (size % alignment)
+        if !size.is_multiple_of(alignment)
+            && xbuf.len() >= alignment - (size % alignment)
         {
             let (_, b) = xbuf.split_at_mut(alignment - (size % alignment));
             *buf = b;
@@ -170,7 +171,8 @@ pub(crate) fn take_body_from_collection<'a>(
     let xbuf = take(&mut *buf);
     if xbuf.len() >= size {
         let (item, xbuf) = xbuf.split_at(size);
-        if size % alignment != 0 && xbuf.len() >= alignment - (size % alignment)
+        if !size.is_multiple_of(alignment)
+            && xbuf.len() >= alignment - (size % alignment)
         {
             let (_, b) = xbuf.split_at(alignment - (size % alignment));
             *buf = b;
@@ -1429,24 +1431,18 @@ impl BoardInstances {
 impl_bitfield_primitive_conversion!(BoardInstances, 0xffff, u16);
 
 pub mod gnb {
-    use super::{
-        BitfieldSpecifier, EntryCompatible, EntryId, FromBytes, FromPrimitive,
-        Getter, GnbEntryId, Immutable, IntoBytes, KnownLayout, Result, Setter,
-        ToPrimitive, Unaligned, make_bitfield_serde, paste,
-    };
     #[cfg(feature = "serde")]
     use super::{Deserialize, SerdeHex8, Serialize};
+    use super::{
+        EntryCompatible, EntryId, FromBytes, FromPrimitive, Getter, GnbEntryId,
+        Immutable, IntoBytes, KnownLayout, Result, Setter, Specifier,
+        ToPrimitive, Unaligned, make_bitfield_serde, paste,
+    };
     use crate::struct_accessors::make_accessors;
     use modular_bitfield::prelude::*;
 
     #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        FromPrimitive,
-        ToPrimitive,
-        BitfieldSpecifier,
+        Clone, Copy, Debug, PartialEq, FromPrimitive, ToPrimitive, Specifier,
     )]
     // FIXME #[non_exhaustive]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -1466,13 +1462,7 @@ pub mod gnb {
     //impl_bitfield_primitive_conversion!(LrdimmDdr4DimmRanks, 0b11, u32);
 
     #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        FromPrimitive,
-        ToPrimitive,
-        BitfieldSpecifier,
+        Clone, Copy, Debug, PartialEq, FromPrimitive, ToPrimitive, Specifier,
     )]
     // FIXME #[non_exhaustive]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -1515,7 +1505,7 @@ pub mod gnb {
         #[bitfield(bits = 64)]
         #[repr(u64)]
         #[derive(
-            Clone, Copy, Debug, PartialEq, //BitfieldSpecifier,
+            Clone, Copy, Debug, PartialEq, //Specifier,
         )]
         pub struct EarlyPcieConfigBody {
             #[bits = 8]
@@ -2624,7 +2614,7 @@ pub mod memory {
         /// allows either single or dual rank.
         #[bitfield(bits = 4)]
         #[derive(
-            Default, Clone, Copy, PartialEq, BitfieldSpecifier,
+            Default, Clone, Copy, PartialEq, Specifier,
         )]
         pub struct Ddr4DimmRanks {
             #[bits = 1]
@@ -2660,7 +2650,7 @@ pub mod memory {
         /// either unpopulated or lr.
         #[bitfield(bits = 4)]
         #[derive(
-            Clone, Copy, PartialEq, BitfieldSpecifier,
+            Clone, Copy, PartialEq, Specifier,
         )]
         pub struct LrdimmDdr4DimmRanks {
             #[bits = 1]
@@ -4736,7 +4726,7 @@ Clone)]
     make_bitfield_serde! {
         #[bitfield(bits = 32)]
         #[repr(u32)]
-        #[derive(Default, Clone, Copy, BitfieldSpecifier)]
+        #[derive(Default, Clone, Copy, Specifier)]
         pub struct Ddr4OdtPatDimmRankBitmaps {
             #[bits = 4]
             pub dimm0: Ddr4DimmRanks | pub get Ddr4DimmRanks : pub set Ddr4DimmRanks, // @0
@@ -4825,7 +4815,7 @@ Clone)]
     make_bitfield_serde! {
         #[bitfield(bits = 32)]
         #[repr(u32)]
-        #[derive(Clone, Copy, BitfieldSpecifier)]
+        #[derive(Clone, Copy, Specifier)]
         pub struct LrdimmDdr4OdtPatDimmRankBitmaps {
             pub dimm0: LrdimmDdr4DimmRanks | pub get LrdimmDdr4DimmRanks : pub set LrdimmDdr4DimmRanks, // @bit 0
             pub dimm1: LrdimmDdr4DimmRanks | pub get LrdimmDdr4DimmRanks : pub set LrdimmDdr4DimmRanks, // @bit 4
@@ -4893,7 +4883,7 @@ Clone)]
     }
 
     /*
-        #[derive(BitfieldSpecifier, Debug, PartialEq)]
+        #[derive(Specifier, Debug, PartialEq)]
         #[bits = 1]
         pub enum DdrPostPackageRepairBodyDeviceWidth {
             Width0 = 0,
@@ -5910,7 +5900,7 @@ Clone)]
     make_bitfield_serde!(
         #[bitfield(bits = 12)]
         #[derive(
-            Default, Clone, Copy, PartialEq, BitfieldSpecifier,
+            Default, Clone, Copy, PartialEq, Specifier,
         )]
         pub struct Ddr5TrainingOverrideEntryHeaderChannelSelectorMask {
             pub c_0: bool | pub get bool : pub set bool,
@@ -5931,7 +5921,7 @@ Clone)]
     make_bitfield_serde!(
         #[bitfield(bits = 4)]
         #[derive(
-            Default, Clone, Copy, PartialEq, BitfieldSpecifier,
+            Default, Clone, Copy, PartialEq, Specifier,
         )]
         pub struct Ddr5TrainingOverrideEntryHeaderFlagsMemClkMask {
             pub ddr4800: bool | pub get bool : pub set bool,
@@ -5943,7 +5933,7 @@ Clone)]
 
     // Note: Using make_bitfield_serde would expose the fact that modular-bitfield doesn't actually have i8 (or i4).
     #[bitfield(bits = 32)]
-    #[derive(Default, Clone, Copy, PartialEq, BitfieldSpecifier)]
+    #[derive(Default, Clone, Copy, PartialEq, Specifier)]
     pub(crate) struct Ddr5TrainingOverrideEntryHeaderFlags {
         pub selected_mem_clks: Ddr5TrainingOverrideEntryHeaderFlagsMemClkMask,
         pub selected_channels:
@@ -10804,7 +10794,7 @@ pub enum DfPdrMode {
     Selective = 1,
 }
 
-#[derive(BitfieldSpecifier, Copy, Clone, Debug, Default, PartialEq)]
+#[derive(Specifier, Copy, Clone, Debug, Default, PartialEq)]
 #[bits = 1]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]


### PR DESCRIPTION
- Use `is_multiple_of` instead of manual alignment check
- Update to modular-bitfield 0.13 to fix unnecessary parentheses warnings in generated `#[bitfield]` code
- Remove unused `Serde*` structs in cases we have a `CustomSerde*` type (`EarlyPcieConfigElement`, `ErrorOutControlBeepCode`, `DdrPostPackageRepairElement`, `RdimmDdr4Voltages`, `UdimmDdr4Voltages`, `LrdimmDdr4Voltages`)